### PR TITLE
Fix loss of custom domain for every new render to gh-pages branch

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+mathesis.jakobarendt.com

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,5 +1,7 @@
 project:
   type: book
+  resources:
+    - CNAME
 
 book:
   title: "Climate Change und Rural Depopulation"


### PR DESCRIPTION
Until now, every new render of output onto the gh-pages branch deleted the CNAME file that configures the custom domain for the book project webpage.

Adding the CNAME file to the project root directory and specifying it as a resource in the _quarto.yml is supposed to solve this. More information can be found here:
<https://github.com/quarto-dev/quarto-cli/discussions/3249>

However, two uncertainties remain:
- Is the `resources:` correctly mentioned below `project:`? Or should it be mentioned below `html:` or stand by itself instead (in the YAML)?
- Could this conflict later onwards with the PDF output format?